### PR TITLE
Fix PrintMessage to use chatMessage argument

### DIFF
--- a/Assets/LoopModding/Core/Scripts/ModAPI.cs
+++ b/Assets/LoopModding/Core/Scripts/ModAPI.cs
@@ -28,12 +28,12 @@ namespace LoopModding.Core.API{
             {
                 if (args.HasKey("chatMessage"))
                 {
-                    string msg = args["message"];
+                    string msg = args["chatMessage"];
                     GameManager.instance.chatText.text += msg + "\n";
                 }
                 else
                 {
-                    Debug.LogWarning("[MOD] PrintMessage missing 'message' argument.");
+                    Debug.LogWarning("[MOD] PrintMessage missing 'chatMessage' argument.");
                 }
             });
 


### PR DESCRIPTION
## Summary
- align the PrintMessage handler with the chatMessage argument so mods append the intended chat text

## Testing
- not run (Unity environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c91bc89458832aaaecb88435ba375f