### PR TITLE
Improve runtime argument resolution for mods

### DIFF
--- a/Assets/LoopModding/Core/Scripts/ModManager.cs
+++ b/Assets/LoopModding/Core/Scripts/ModManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using SimpleJSON;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using LoopModding.Core.API;
 
 namespace LoopModding.Core
@@ -9,6 +10,8 @@ namespace LoopModding.Core
     public class ModManager : MonoBehaviour
     {
         public static ModManager Instance;
+
+        private static readonly Regex placeholderRegex = new("@(?:\\{(?<braced>[A-Za-z0-9_]+)\\}|(?<key>[A-Za-z0-9_]+))");
 
         private Dictionary<string, List<ModDefinition>> eventMap = new();
         private Dictionary<string, JSONNode> parameters = new();
@@ -28,7 +31,7 @@ namespace LoopModding.Core
             LoadAllMods();
         }
 
-          private void LoadAllParameters()
+        private void LoadAllParameters()
         {
             string path = Path.Combine(Application.dataPath, "../Mods/Parameters/");
             if (!Directory.Exists(path))
@@ -75,41 +78,11 @@ namespace LoopModding.Core
                     args = node["args"]
                 };
 
-                if (mod.args != null)
-                    ResolveParameterReferences(mod.args);
-
                 if (!eventMap.ContainsKey(mod.eventName))
                     eventMap[mod.eventName] = new List<ModDefinition>();
 
                 eventMap[mod.eventName].Add(mod);
                 Debug.Log($"[ModManager] Loaded mod: {mod.modName} for event {mod.eventName}");
-            }
-        }
-
-        private void ResolveParameterReferences(JSONNode args)
-        {
-            List<string> keysToCheck = new List<string>();
-
-            foreach (var key in args.Keys)
-            {
-                keysToCheck.Add(key); // 🔁 on clone manuellement les clés
-            }
-
-            foreach (var key in keysToCheck)
-            {
-                if (args[key] is JSONString str && str.Value.StartsWith("@"))
-                {
-                    string refKey = str.Value.Substring(1);
-                    if (parameters.TryGetValue(refKey, out var resolvedValue))
-                    {
-                        args[key] = resolvedValue;
-                        Debug.Log($"[ModManager] Resolved '@{refKey}' → {resolvedValue}");
-                    }
-                    else
-                    {
-                        Debug.LogWarning($"[ModManager] Missing param '@{refKey}'");
-                    }
-                }
             }
         }
 
@@ -211,33 +184,162 @@ namespace LoopModding.Core
 
         private JSONNode ResolveArgs(JSONNode args)
         {
-            var resolved = new JSONObject();
+            if (args == null || args.Tag == JSONNodeType.None || args.Tag == JSONNodeType.NullValue)
+                return new JSONObject();
 
-            foreach (KeyValuePair<string, JSONNode> kvp in args)
+            return ResolveNode(args, new HashSet<string>());
+        }
+
+        private JSONNode ResolveNode(JSONNode node, HashSet<string> visitedKeys)
+        {
+            if (node == null)
+                return JSONNull.CreateOrGet();
+
+            switch (node.Tag)
             {
-                JSONNode value = kvp.Value;
+                case JSONNodeType.Object:
+                    var obj = new JSONObject();
+                    foreach (KeyValuePair<string, JSONNode> kvp in node.AsObject)
+                        obj[kvp.Key] = ResolveNode(kvp.Value, visitedKeys);
+                    return obj;
+                case JSONNodeType.Array:
+                    var array = new JSONArray();
+                    foreach (JSONNode child in node.AsArray)
+                        array.Add(ResolveNode(child, visitedKeys));
+                    return array;
+                case JSONNodeType.String:
+                    return ResolveStringNode(node.Value, visitedKeys);
+                case JSONNodeType.None:
+                    return JSONNull.CreateOrGet();
+                default:
+                    return node.Clone();
+            }
+        }
 
-                if (value is JSONString str && str.Value.StartsWith("@"))
+        private JSONNode ResolveStringNode(string value, HashSet<string> visitedKeys)
+        {
+            if (string.IsNullOrEmpty(value))
+                return new JSONString(string.Empty);
+
+            if (TryGetExactPlaceholder(value, out string key))
+            {
+                if (visitedKeys.Contains(key))
                 {
-                    string key = str.Value.Substring(1);
+                    Debug.LogWarning($"[ModManager] Detected circular parameter reference: @{key}");
+                    return new JSONString(value);
+                }
+
+                visitedKeys.Add(key);
+
+                try
+                {
                     if (parameters.TryGetValue(key, out var param))
                     {
-                        resolved[kvp.Key] = param;
-                        Debug.Log($"[ModManager] Resolved @{key} → {param}");
+                        JSONNode resolved = ResolveNode(param, visitedKeys);
+                        Debug.Log($"[ModManager] Resolved @{key} → {resolved}");
+                        return resolved;
                     }
-                    else
-                    {
-                        Debug.LogWarning($"[ModManager] Missing parameter: @{key}");
-                        resolved[kvp.Key] = value;
-                    }
+
+                    Debug.LogWarning($"[ModManager] Missing parameter: @{key}");
+                    return new JSONString(value);
                 }
-                else
+                finally
                 {
-                    resolved[kvp.Key] = value;
+                    visitedKeys.Remove(key);
                 }
             }
 
-            return resolved;
+            if (!value.Contains("@"))
+                return new JSONString(value);
+
+            string replaced = placeholderRegex.Replace(value, match =>
+            {
+                string placeholderKey = match.Groups["braced"].Success
+                    ? match.Groups["braced"].Value
+                    : match.Groups["key"].Value;
+                if (!IsValidPlaceholderKey(placeholderKey))
+                    return match.Value;
+                if (visitedKeys.Contains(placeholderKey))
+                {
+                    Debug.LogWarning($"[ModManager] Detected circular parameter reference: @{placeholderKey}");
+                    return match.Value;
+                }
+
+                visitedKeys.Add(placeholderKey);
+
+                try
+                {
+                    if (parameters.TryGetValue(placeholderKey, out var param))
+                    {
+                        JSONNode resolved = ResolveNode(param, visitedKeys);
+                        Debug.Log($"[ModManager] Resolved @{placeholderKey} → {resolved}");
+                        return GetNodeStringValue(resolved);
+                    }
+
+                    Debug.LogWarning($"[ModManager] Missing parameter: @{placeholderKey}");
+                    return match.Value;
+                }
+                finally
+                {
+                    visitedKeys.Remove(placeholderKey);
+                }
+            });
+
+            return new JSONString(replaced);
+        }
+
+        private static bool TryGetExactPlaceholder(string value, out string key)
+        {
+            key = string.Empty;
+
+            if (string.IsNullOrEmpty(value) || value[0] != '@')
+                return false;
+
+            if (value.Length > 2 && value[1] == '{' && value[^1] == '}')
+            {
+                string candidate = value.Substring(2, value.Length - 3);
+                if (IsValidPlaceholderKey(candidate))
+                {
+                    key = candidate;
+                    return true;
+                }
+
+                return false;
+            }
+
+            string fallback = value.Substring(1);
+            if (IsValidPlaceholderKey(fallback))
+            {
+                key = fallback;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsValidPlaceholderKey(string candidate)
+        {
+            if (string.IsNullOrEmpty(candidate))
+                return false;
+
+            foreach (char c in candidate)
+            {
+                if (!(char.IsLetterOrDigit(c) || c == '_'))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private string GetNodeStringValue(JSONNode node)
+        {
+            if (node == null)
+                return string.Empty;
+
+            if (node.Tag == JSONNodeType.Array || node.Tag == JSONNodeType.Object)
+                return node.ToString();
+
+            return node.Value;
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
## Summary
- rework `ResolveArgs` to resolve parameter placeholders recursively, covering objects, arrays, inline strings, and supporting `@{key}` syntax with cycle detection
- rely solely on runtime resolution by removing the pre-load `ResolveParameterReferences` helper so mods remain untouched until execution

## Testing
- python - <<'PY' ... PY

------
https://chatgpt.com/codex/tasks/task_e_68c91d74cfd0832ab40fd5b3d200eb7f