### PR TITLE
Add UI runtime utilities and input binding actions

### DIFF
--- a/Assets/LoopModding/Core/Scripts/BindInputAction.cs
+++ b/Assets/LoopModding/Core/Scripts/BindInputAction.cs
@@ -1,0 +1,109 @@
+using System;
+using LoopModding.Core.Runtime;
+using SimpleJSON;
+using UnityEngine;
+
+namespace LoopModding.Core.API
+{
+    /// <summary>
+    /// Binds a keyboard key and/or UI button to trigger a mod event.
+    /// </summary>
+    public class BindInputAction : ModApiAction
+    {
+        public override string ActionName => "BindInput";
+
+        public override void Execute(JSONNode args)
+        {
+            if (args == null)
+            {
+                Debug.LogWarning("[MOD] BindInput called without arguments.");
+                return;
+            }
+
+            string eventName = args.HasKey("eventName") ? args["eventName"].Value : string.Empty;
+            if (string.IsNullOrWhiteSpace(eventName))
+            {
+                Debug.LogWarning("[MOD] BindInput requires an 'eventName'.");
+                return;
+            }
+
+            string id = args.HasKey("id") ? args["id"].Value : eventName;
+            string keyArg = args.HasKey("key") ? args["key"].Value : string.Empty;
+            KeyCode? key = TryParseKey(keyArg);
+
+            string triggerArg = args.HasKey("trigger") ? args["trigger"].Value : "Down";
+            ModInputRuntime.KeyTrigger trigger = ParseTrigger(triggerArg);
+
+            float holdDelay = args.HasKey("holdDelay") ? Mathf.Max(0f, args["holdDelay"].AsFloat) : 0f;
+            float repeatInterval = args.HasKey("repeatInterval") ? Mathf.Max(0f, args["repeatInterval"].AsFloat) : 0f;
+
+            string buttonLabel = args.HasKey("buttonLabel") ? args["buttonLabel"].Value : null;
+            bool buttonInteractable = !args.HasKey("buttonInteractable") || args["buttonInteractable"].AsBool;
+            float buttonDuration = args.HasKey("buttonDuration") ? Mathf.Max(0f, args["buttonDuration"].AsFloat) : 0f;
+            bool buttonNormalized = args.HasKey("buttonNormalized") && args["buttonNormalized"].AsBool;
+            float buttonX = args.HasKey("buttonX") ? args["buttonX"].AsFloat : 0.5f;
+            float buttonY = args.HasKey("buttonY") ? args["buttonY"].AsFloat : 0.15f;
+            float buttonWidth = args.HasKey("buttonWidth") ? Mathf.Max(0f, args["buttonWidth"].AsFloat) : 220f;
+            float buttonHeight = args.HasKey("buttonHeight") ? Mathf.Max(0f, args["buttonHeight"].AsFloat) : 60f;
+            float buttonPivotX = args.HasKey("buttonPivotX") ? Mathf.Clamp01(args["buttonPivotX"].AsFloat) : 0.5f;
+            float buttonPivotY = args.HasKey("buttonPivotY") ? Mathf.Clamp01(args["buttonPivotY"].AsFloat) : 0.5f;
+
+            if (key == null && string.IsNullOrWhiteSpace(buttonLabel))
+            {
+                Debug.LogWarning("[MOD] BindInput requires at least a 'key' or a 'buttonLabel'.");
+                return;
+            }
+
+            ModInputRuntime runtime = ModInputRuntime.EnsureInstance();
+            ModInputRuntime.InputBindingOptions options = new()
+            {
+                Id = id,
+                EventName = eventName,
+                Key = key,
+                Trigger = trigger,
+                HoldDelay = holdDelay,
+                RepeatInterval = repeatInterval,
+                ButtonLabel = buttonLabel,
+                ButtonInteractable = buttonInteractable,
+                ButtonDuration = buttonDuration,
+                ButtonPosition = buttonNormalized
+                    ? new Vector2(Mathf.Clamp01(buttonX), Mathf.Clamp01(buttonY))
+                    : new Vector2(buttonX, buttonY),
+                ButtonPositionMode = buttonNormalized
+                    ? ModUiRuntime.PositionMode.Normalized
+                    : ModUiRuntime.PositionMode.Pixel,
+                ButtonSize = new Vector2(buttonWidth, buttonHeight),
+                ButtonPivot = new Vector2(buttonPivotX, buttonPivotY)
+            };
+
+            string registeredId = runtime.RegisterBinding(options);
+            Debug.Log($"[MOD] BindInput registered '{registeredId}' for event '{eventName}'.");
+        }
+
+        private static KeyCode? TryParseKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            if (Enum.TryParse(value, true, out KeyCode result))
+            {
+                return result;
+            }
+
+            Debug.LogWarning($"[MOD] BindInput could not parse key '{value}'.");
+            return null;
+        }
+
+        private static ModInputRuntime.KeyTrigger ParseTrigger(string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value) && Enum.TryParse(value, true, out ModInputRuntime.KeyTrigger trigger))
+            {
+                return trigger;
+            }
+
+            return ModInputRuntime.KeyTrigger.Down;
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/BindInputAction.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/BindInputAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32e0558749de46e19039eeaca0d46257

--- a/Assets/LoopModding/Core/Scripts/DrawTextAction.cs
+++ b/Assets/LoopModding/Core/Scripts/DrawTextAction.cs
@@ -1,0 +1,114 @@
+using System;
+using LoopModding.Core.Runtime;
+using SimpleJSON;
+using TMPro;
+using UnityEngine;
+
+namespace LoopModding.Core.API
+{
+    /// <summary>
+    /// Displays a configurable text element on the mod UI canvas.
+    /// </summary>
+    public class DrawTextAction : ModApiAction
+    {
+        public override string ActionName => "DrawText";
+
+        public override void Execute(JSONNode args)
+        {
+            if (args == null)
+            {
+                Debug.LogWarning("[MOD] DrawText called without arguments.");
+                return;
+            }
+
+            string text = args.HasKey("text") ? args["text"].Value : string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                Debug.LogWarning("[MOD] DrawText requires a non-empty 'text' argument.");
+                return;
+            }
+
+            string id = args.HasKey("id") ? args["id"].Value : null;
+            float x = args.HasKey("x") ? args["x"].AsFloat : 0.5f;
+            float y = args.HasKey("y") ? args["y"].AsFloat : 0.5f;
+            bool normalized = args.HasKey("normalized") && args["normalized"].AsBool;
+            float duration = args.HasKey("duration") ? Mathf.Max(0f, args["duration"].AsFloat) : 0f;
+            bool raycastTarget = args.HasKey("raycastTarget") && args["raycastTarget"].AsBool;
+
+            int fontSize = args.HasKey("fontSize") ? Mathf.Max(1, args["fontSize"].AsInt) : 32;
+            string colorArg = args.HasKey("color") ? args["color"].Value : "#FFFFFF";
+            string alignmentArg = args.HasKey("alignment") ? args["alignment"].Value : "Center";
+            string styleArg = args.HasKey("fontStyle") ? args["fontStyle"].Value : string.Empty;
+
+            float width = args.HasKey("width") ? Mathf.Max(0f, args["width"].AsFloat) : 0f;
+            float height = args.HasKey("height") ? Mathf.Max(0f, args["height"].AsFloat) : 0f;
+            float pivotX = args.HasKey("pivotX") ? Mathf.Clamp01(args["pivotX"].AsFloat) : 0.5f;
+            float pivotY = args.HasKey("pivotY") ? Mathf.Clamp01(args["pivotY"].AsFloat) : 0.5f;
+
+            if (!ModUiRuntime.TryParseColor(colorArg, out Color color))
+            {
+                Debug.LogWarning($"[MOD] DrawText received an invalid color '{colorArg}'. Falling back to white.");
+                color = Color.white;
+            }
+
+            TextAlignmentOptions alignment = ParseAlignment(alignmentArg);
+            FontStyles fontStyle = ParseFontStyle(styleArg);
+
+            Vector2 position = normalized ? new Vector2(Mathf.Clamp01(x), Mathf.Clamp01(y)) : new Vector2(x, y);
+            Vector2? size = (width > 0f && height > 0f) ? new Vector2(width, height) : (Vector2?)null;
+            Vector2 pivot = new Vector2(pivotX, pivotY);
+
+            ModUiRuntime runtime = ModUiRuntime.EnsureInstance();
+            string elementId = runtime.DrawText(
+                id,
+                text,
+                position,
+                normalized ? ModUiRuntime.PositionMode.Normalized : ModUiRuntime.PositionMode.Pixel,
+                color,
+                fontSize,
+                alignment,
+                fontStyle,
+                raycastTarget,
+                size,
+                pivot,
+                duration);
+
+            Debug.Log($"[MOD] DrawText displayed text with id '{elementId}'.");
+        }
+
+        private static TextAlignmentOptions ParseAlignment(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return TextAlignmentOptions.Center;
+            }
+
+            if (Enum.TryParse(value, true, out TextAlignmentOptions alignment))
+            {
+                return alignment;
+            }
+
+            return TextAlignmentOptions.Center;
+        }
+
+        private static FontStyles ParseFontStyle(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return FontStyles.Normal;
+            }
+
+            FontStyles style = FontStyles.Normal;
+            string[] parts = value.Split('|');
+            foreach (string part in parts)
+            {
+                if (Enum.TryParse(part.Trim(), true, out FontStyles parsed))
+                {
+                    style |= parsed;
+                }
+            }
+
+            return style;
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/DrawTextAction.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/DrawTextAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c603f9131869496688c0f5815910cf06

--- a/Assets/LoopModding/Core/Scripts/ModInputRuntime.cs
+++ b/Assets/LoopModding/Core/Scripts/ModInputRuntime.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using LoopModding.Core;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace LoopModding.Core.Runtime
+{
+    /// <summary>
+    /// Handles key and UI button bindings registered through the ModAPI.
+    /// </summary>
+    public class ModInputRuntime : MonoBehaviour
+    {
+        public enum KeyTrigger
+        {
+            Down,
+            Up,
+            Held
+        }
+
+        private class InputBinding
+        {
+            public string Id;
+            public string EventName;
+            public KeyCode? Key;
+            public KeyTrigger Trigger;
+            public float HoldDelay;
+            public float RepeatInterval;
+            public float NextFireTime;
+            public Button Button;
+        }
+
+        public struct InputBindingOptions
+        {
+            public string Id;
+            public string EventName;
+            public KeyCode? Key;
+            public KeyTrigger Trigger;
+            public float HoldDelay;
+            public float RepeatInterval;
+            public string ButtonLabel;
+            public Vector2 ButtonPosition;
+            public ModUiRuntime.PositionMode ButtonPositionMode;
+            public Vector2 ButtonSize;
+            public Vector2 ButtonPivot;
+            public bool ButtonInteractable;
+            public float ButtonDuration;
+        }
+
+        private const string RuntimeName = "ModInputRuntime";
+
+        public static ModInputRuntime Instance { get; private set; }
+
+        private readonly Dictionary<string, InputBinding> bindings = new();
+        private ModManager cachedManager;
+
+        public static ModInputRuntime EnsureInstance()
+        {
+            if (Instance != null)
+            {
+                return Instance;
+            }
+
+            ModInputRuntime existing = FindObjectOfType<ModInputRuntime>();
+            if (existing != null)
+            {
+                Instance = existing;
+                Instance.Initialize();
+                return Instance;
+            }
+
+            GameObject go = new(RuntimeName);
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<ModInputRuntime>();
+            Instance.Initialize();
+            return Instance;
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            cachedManager = ModManager.Instance;
+        }
+
+        private void Update()
+        {
+            foreach (InputBinding binding in bindings.Values)
+            {
+                if (binding == null || string.IsNullOrEmpty(binding.EventName))
+                {
+                    continue;
+                }
+
+                if (binding.Key.HasValue)
+                {
+                    EvaluateKey(binding);
+                }
+            }
+        }
+
+        private void EvaluateKey(InputBinding binding)
+        {
+            KeyCode key = binding.Key.Value;
+            switch (binding.Trigger)
+            {
+                case KeyTrigger.Down:
+                    if (Input.GetKeyDown(key))
+                    {
+                        TriggerBinding(binding);
+                    }
+                    break;
+                case KeyTrigger.Up:
+                    if (Input.GetKeyUp(key))
+                    {
+                        TriggerBinding(binding);
+                    }
+                    break;
+                case KeyTrigger.Held:
+                    if (Input.GetKeyDown(key))
+                    {
+                        binding.NextFireTime = Time.time + Mathf.Max(0f, binding.HoldDelay);
+                    }
+
+                    if (Input.GetKey(key) && Time.time >= binding.NextFireTime)
+                    {
+                        TriggerBinding(binding);
+                        if (binding.RepeatInterval > 0f)
+                        {
+                            binding.NextFireTime = Time.time + binding.RepeatInterval;
+                        }
+                        else
+                        {
+                            binding.NextFireTime = float.PositiveInfinity;
+                        }
+                    }
+
+                    if (Input.GetKeyUp(key))
+                    {
+                        binding.NextFireTime = 0f;
+                    }
+                    break;
+            }
+        }
+
+        private void TriggerBinding(InputBinding binding)
+        {
+            if (cachedManager == null)
+            {
+                cachedManager = ModManager.Instance;
+            }
+
+            if (cachedManager == null)
+            {
+                Debug.LogWarning("[ModInputRuntime] Unable to trigger event because ModManager is missing.");
+                return;
+            }
+
+            cachedManager.TriggerEvent(binding.EventName);
+        }
+
+        public string RegisterBinding(InputBindingOptions options)
+        {
+            string id = string.IsNullOrWhiteSpace(options.Id) ? Guid.NewGuid().ToString("N") : options.Id;
+            InputBinding binding = GetOrCreateBinding(id);
+
+            binding.EventName = options.EventName;
+            binding.Key = options.Key;
+            binding.Trigger = options.Trigger;
+            binding.HoldDelay = Mathf.Max(0f, options.HoldDelay);
+            binding.RepeatInterval = Mathf.Max(0f, options.RepeatInterval);
+            binding.NextFireTime = 0f;
+
+            if (!string.IsNullOrWhiteSpace(options.ButtonLabel))
+            {
+                ModUiRuntime uiRuntime = ModUiRuntime.EnsureInstance();
+                string buttonId = uiRuntime.CreateOrUpdateButton(
+                    id,
+                    options.ButtonLabel,
+                    options.ButtonPosition,
+                    options.ButtonPositionMode,
+                    options.ButtonSize,
+                    options.ButtonPivot,
+                    () => TriggerBinding(binding),
+                    options.ButtonInteractable,
+                    options.ButtonDuration,
+                    out Button button);
+
+                binding.Button = button;
+                binding.Button.name = $"ModUIButton_{buttonId}";
+            }
+            else if (binding.Button != null)
+            {
+                ModUiRuntime.EnsureInstance().RemoveButton(id);
+                binding.Button = null;
+            }
+
+            bindings[id] = binding;
+            return id;
+        }
+
+        public bool UnregisterBinding(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return false;
+            }
+
+            if (!bindings.TryGetValue(id, out InputBinding binding))
+            {
+                return false;
+            }
+
+            if (binding.Button != null)
+            {
+                ModUiRuntime.EnsureInstance().RemoveButton(id);
+            }
+
+            bindings.Remove(id);
+            return true;
+        }
+
+        private InputBinding GetOrCreateBinding(string id)
+        {
+            if (bindings.TryGetValue(id, out InputBinding binding))
+            {
+                return binding;
+            }
+
+            binding = new InputBinding { Id = id };
+            bindings[id] = binding;
+            return binding;
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/ModInputRuntime.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/ModInputRuntime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8786791f2184433ca0ea0fc5f2c14a55

--- a/Assets/LoopModding/Core/Scripts/ModUiRuntime.cs
+++ b/Assets/LoopModding/Core/Scripts/ModUiRuntime.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Networking;
+using UnityEngine.UI;
+
+namespace LoopModding.Core.Runtime
+{
+    /// <summary>
+    /// Runtime helper used by ModAPI actions to spawn UI elements (texts, images, buttons).
+    /// Creates a lightweight canvas automatically when first accessed.
+    /// </summary>
+    public class ModUiRuntime : MonoBehaviour
+    {
+        public enum PositionMode
+        {
+            Pixel,
+            Normalized
+        }
+
+        private const string DefaultCanvasName = "ModUIRoot";
+
+        public static ModUiRuntime Instance { get; private set; }
+
+        [Header("Canvas Setup")]
+        [SerializeField] private Canvas rootCanvas;
+        [SerializeField] private RectTransform imageRoot;
+        [SerializeField] private RectTransform textRoot;
+        [SerializeField] private RectTransform buttonRoot;
+
+        private readonly Dictionary<string, RawImage> imageRegistry = new();
+        private readonly Dictionary<string, bool> imageAspectPreference = new();
+        private readonly Dictionary<string, Vector2> imageBaseSize = new();
+        private readonly Dictionary<string, TMP_Text> textRegistry = new();
+        private readonly Dictionary<string, Button> buttonRegistry = new();
+
+        private readonly Dictionary<string, Coroutine> imageTimers = new();
+        private readonly Dictionary<string, Coroutine> textTimers = new();
+        private readonly Dictionary<string, Coroutine> buttonTimers = new();
+
+        public static ModUiRuntime EnsureInstance()
+        {
+            if (Instance != null)
+            {
+                return Instance;
+            }
+
+            ModUiRuntime existing = FindObjectOfType<ModUiRuntime>();
+            if (existing != null)
+            {
+                Instance = existing;
+                Instance.Initialize();
+                return Instance;
+            }
+
+            GameObject runtimeGo = new(DefaultCanvasName);
+            DontDestroyOnLoad(runtimeGo);
+            Instance = runtimeGo.AddComponent<ModUiRuntime>();
+            Instance.Initialize();
+            return Instance;
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            EnsureEventSystem();
+            EnsureCanvasHierarchy();
+        }
+
+        private void EnsureEventSystem()
+        {
+            if (EventSystem.current != null)
+            {
+                return;
+            }
+
+            GameObject eventSystemObj = new("ModUI_EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            DontDestroyOnLoad(eventSystemObj);
+        }
+
+        private void EnsureCanvasHierarchy()
+        {
+            if (rootCanvas == null)
+            {
+                rootCanvas = GetComponentInChildren<Canvas>();
+            }
+
+            if (rootCanvas == null)
+            {
+                GameObject canvasObj = new("ModUICanvas");
+                canvasObj.layer = LayerMask.NameToLayer("UI");
+                canvasObj.transform.SetParent(transform, false);
+
+                rootCanvas = canvasObj.AddComponent<Canvas>();
+                rootCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+                CanvasScaler scaler = canvasObj.AddComponent<CanvasScaler>();
+                scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+                scaler.referenceResolution = new Vector2(1920, 1080);
+
+                canvasObj.AddComponent<GraphicRaycaster>();
+            }
+
+            imageRoot ??= CreateLayerRoot("Images");
+            textRoot ??= CreateLayerRoot("Texts");
+            buttonRoot ??= CreateLayerRoot("Buttons");
+        }
+
+        private RectTransform CreateLayerRoot(string suffix)
+        {
+            GameObject go = new($"ModUI_{suffix}", typeof(RectTransform));
+            RectTransform rect = go.GetComponent<RectTransform>();
+            rect.SetParent(rootCanvas.transform, false);
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            return rect;
+        }
+
+        public string DrawText(
+            string desiredId,
+            string text,
+            Vector2 position,
+            PositionMode positionMode,
+            Color color,
+            int fontSize,
+            TextAlignmentOptions alignment,
+            FontStyles fontStyle,
+            bool raycastTarget,
+            Vector2? size,
+            Vector2 pivot,
+            float durationSeconds)
+        {
+            EnsureCanvasHierarchy();
+
+            string id = string.IsNullOrWhiteSpace(desiredId) ? Guid.NewGuid().ToString("N") : desiredId;
+            TMP_Text element = GetOrCreateText(id);
+            element.text = text ?? string.Empty;
+            element.color = color;
+            element.fontSize = Mathf.Max(1, fontSize);
+            element.alignment = alignment;
+            element.fontStyle = fontStyle;
+            element.raycastTarget = raycastTarget;
+            element.enableWordWrapping = true;
+
+            RectTransform rect = element.rectTransform;
+            ApplyPosition(rect, position, positionMode, pivot);
+            ApplySize(rect, size);
+
+            RestartTimer(textTimers, id, durationSeconds, () => RemoveText(id));
+
+            return id;
+        }
+
+        public string ShowImage(
+            string desiredId,
+            string url,
+            Vector2 position,
+            PositionMode positionMode,
+            Vector2 size,
+            Vector2 pivot,
+            float rotation,
+            Color color,
+            bool preserveAspect,
+            float durationSeconds)
+        {
+            EnsureCanvasHierarchy();
+
+            string id = string.IsNullOrWhiteSpace(desiredId) ? Guid.NewGuid().ToString("N") : desiredId;
+            RawImage image = GetOrCreateImage(id);
+            image.color = color;
+            image.raycastTarget = true;
+            image.transform.localEulerAngles = new Vector3(0f, 0f, rotation);
+            image.texture = null;
+            image.uvRect = new Rect(0f, 0f, 1f, 1f);
+
+            RectTransform rect = image.rectTransform;
+            ApplyPosition(rect, position, positionMode, pivot);
+            ApplySize(rect, size);
+
+            imageAspectPreference[id] = preserveAspect;
+            imageBaseSize[id] = size;
+            StartCoroutine(LoadImageCoroutine(url, image, id));
+
+            RestartTimer(imageTimers, id, durationSeconds, () => RemoveImage(id));
+
+            return id;
+        }
+
+        public string CreateOrUpdateButton(
+            string desiredId,
+            string label,
+            Vector2 position,
+            PositionMode positionMode,
+            Vector2 size,
+            Vector2 pivot,
+            Action onClick,
+            bool interactable,
+            float durationSeconds,
+            out Button button)
+        {
+            EnsureCanvasHierarchy();
+
+            string id = string.IsNullOrWhiteSpace(desiredId) ? Guid.NewGuid().ToString("N") : desiredId;
+            button = GetOrCreateButton(id);
+            button.interactable = interactable;
+
+            TMP_Text textComponent = button.GetComponentInChildren<TMP_Text>();
+            if (textComponent == null)
+            {
+                textComponent = CreateButtonLabel(button.transform);
+            }
+            textComponent.text = label ?? "Button";
+
+            button.onClick.RemoveAllListeners();
+            if (onClick != null)
+            {
+                button.onClick.AddListener(() => onClick.Invoke());
+            }
+
+            RectTransform rect = button.GetComponent<RectTransform>();
+            ApplyPosition(rect, position, positionMode, pivot);
+            ApplySize(rect, size);
+
+            RestartTimer(buttonTimers, id, durationSeconds, () => RemoveButton(id));
+
+            return id;
+        }
+
+        public void RemoveImage(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            if (imageTimers.TryGetValue(id, out Coroutine timer))
+            {
+                StopCoroutine(timer);
+                imageTimers.Remove(id);
+            }
+
+            if (imageRegistry.TryGetValue(id, out RawImage image))
+            {
+                Destroy(image.gameObject);
+                imageRegistry.Remove(id);
+            }
+
+            imageAspectPreference.Remove(id);
+            imageBaseSize.Remove(id);
+        }
+
+        public void RemoveText(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            if (textTimers.TryGetValue(id, out Coroutine timer))
+            {
+                StopCoroutine(timer);
+                textTimers.Remove(id);
+            }
+
+            if (textRegistry.TryGetValue(id, out TMP_Text text))
+            {
+                Destroy(text.gameObject);
+                textRegistry.Remove(id);
+            }
+        }
+
+        public void RemoveButton(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            if (buttonTimers.TryGetValue(id, out Coroutine timer))
+            {
+                StopCoroutine(timer);
+                buttonTimers.Remove(id);
+            }
+
+            if (buttonRegistry.TryGetValue(id, out Button button))
+            {
+                Destroy(button.gameObject);
+                buttonRegistry.Remove(id);
+            }
+        }
+
+        private TMP_Text GetOrCreateText(string id)
+        {
+            if (textRegistry.TryGetValue(id, out TMP_Text element) && element != null)
+            {
+                return element;
+            }
+
+            GameObject go = new($"ModUIText_{id}");
+            go.transform.SetParent(textRoot, false);
+
+            RectTransform rect = go.AddComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(300f, 80f);
+
+            TMP_Text text = go.AddComponent<TextMeshProUGUI>();
+            textRegistry[id] = text;
+            return text;
+        }
+
+        private RawImage GetOrCreateImage(string id)
+        {
+            if (imageRegistry.TryGetValue(id, out RawImage image) && image != null)
+            {
+                return image;
+            }
+
+            GameObject go = new($"ModUIImage_{id}");
+            go.transform.SetParent(imageRoot, false);
+
+            RectTransform rect = go.AddComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(256f, 256f);
+
+            RawImage rawImage = go.AddComponent<RawImage>();
+            imageRegistry[id] = rawImage;
+            return rawImage;
+        }
+
+        private Button GetOrCreateButton(string id)
+        {
+            if (buttonRegistry.TryGetValue(id, out Button button) && button != null)
+            {
+                return button;
+            }
+
+            GameObject go = new($"ModUIButton_{id}");
+            go.transform.SetParent(buttonRoot, false);
+
+            RectTransform rect = go.AddComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(160f, 40f);
+
+            Image background = go.AddComponent<Image>();
+            background.color = new Color(0.1f, 0.1f, 0.1f, 0.8f);
+
+            Button newButton = go.AddComponent<Button>();
+            buttonRegistry[id] = newButton;
+            return newButton;
+        }
+
+        private TMP_Text CreateButtonLabel(Transform parent)
+        {
+            GameObject labelGo = new("Label");
+            labelGo.transform.SetParent(parent, false);
+
+            RectTransform rect = labelGo.AddComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            TextMeshProUGUI text = labelGo.AddComponent<TextMeshProUGUI>();
+            text.fontSize = 24f;
+            text.alignment = TextAlignmentOptions.Center;
+            text.color = Color.white;
+            text.enableWordWrapping = false;
+            return text;
+        }
+
+        private void ApplyPosition(RectTransform rect, Vector2 position, PositionMode mode, Vector2 pivot)
+        {
+            rect.pivot = pivot;
+
+            switch (mode)
+            {
+                case PositionMode.Normalized:
+                    rect.anchorMin = position;
+                    rect.anchorMax = position;
+                    rect.anchoredPosition = Vector2.zero;
+                    break;
+                default:
+                    rect.anchorMin = new Vector2(0.5f, 0.5f);
+                    rect.anchorMax = new Vector2(0.5f, 0.5f);
+                    rect.anchoredPosition = position;
+                    break;
+            }
+        }
+
+        private void ApplySize(RectTransform rect, Vector2? size)
+        {
+            if (size.HasValue && size.Value != Vector2.zero)
+            {
+                Vector2 value = size.Value;
+                rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, Mathf.Max(0f, value.x));
+                rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, Mathf.Max(0f, value.y));
+            }
+        }
+
+        private void RestartTimer(Dictionary<string, Coroutine> map, string id, float durationSeconds, Action onComplete)
+        {
+            if (map.TryGetValue(id, out Coroutine previous) && previous != null)
+            {
+                StopCoroutine(previous);
+                map.Remove(id);
+            }
+
+            if (durationSeconds > 0f)
+            {
+                Coroutine timer = StartCoroutine(RemoveAfterDelay(durationSeconds, onComplete));
+                map[id] = timer;
+            }
+        }
+
+        private IEnumerator RemoveAfterDelay(float delay, Action callback)
+        {
+            yield return new WaitForSeconds(delay);
+            callback?.Invoke();
+        }
+
+        private void ApplyImageAspect(RectTransform rect, Vector2 requestedSize, Texture texture)
+        {
+            Vector2 size = CalculateAspectSize(requestedSize, texture);
+            rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, Mathf.Max(0f, size.x));
+            rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, Mathf.Max(0f, size.y));
+        }
+
+        private Vector2 CalculateAspectSize(Vector2 requestedSize, Texture texture)
+        {
+            if (texture == null)
+            {
+                return requestedSize;
+            }
+
+            float texWidth = texture.width;
+            float texHeight = texture.height;
+            if (texWidth <= 0f || texHeight <= 0f)
+            {
+                return requestedSize;
+            }
+
+            if (requestedSize == Vector2.zero)
+            {
+                return new Vector2(texWidth, texHeight);
+            }
+
+            float aspect = texWidth / texHeight;
+
+            float targetWidth = requestedSize.x;
+            float targetHeight = requestedSize.y;
+
+            if (targetWidth <= 0f && targetHeight <= 0f)
+            {
+                return new Vector2(texWidth, texHeight);
+            }
+
+            if (targetWidth <= 0f)
+            {
+                targetWidth = targetHeight * aspect;
+            }
+            else if (targetHeight <= 0f)
+            {
+                targetHeight = targetWidth / aspect;
+            }
+            else
+            {
+                float boxAspect = targetWidth / targetHeight;
+                if (aspect > boxAspect)
+                {
+                    targetHeight = targetWidth / aspect;
+                }
+                else
+                {
+                    targetWidth = targetHeight * aspect;
+                }
+            }
+
+            return new Vector2(targetWidth, targetHeight);
+        }
+
+        private IEnumerator LoadImageCoroutine(string url, RawImage target, string id)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                Debug.LogWarning($"[ModUI] Invalid image url for id '{id}'.");
+                yield break;
+            }
+
+            using UnityWebRequest request = UnityWebRequestTexture.GetTexture(url);
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogWarning($"[ModUI] Failed to download image '{url}' for id '{id}': {request.error}");
+                yield break;
+            }
+
+            Texture2D texture = DownloadHandlerTexture.GetContent(request);
+            target.texture = texture;
+            RectTransform rect = target.rectTransform;
+            if (imageAspectPreference.TryGetValue(id, out bool preserve) && preserve)
+            {
+                Vector2 baseSize = imageBaseSize.TryGetValue(id, out Vector2 requested) ? requested : Vector2.zero;
+                ApplyImageAspect(rect, baseSize, texture);
+            }
+            else if (imageBaseSize.TryGetValue(id, out Vector2 manualSize) && manualSize != Vector2.zero)
+            {
+                ApplySize(rect, manualSize);
+            }
+            else if (texture != null)
+            {
+                ApplySize(rect, new Vector2(texture.width, texture.height));
+            }
+        }
+
+        public static bool TryParseColor(string colorString, out Color color)
+        {
+            color = Color.white;
+            if (string.IsNullOrWhiteSpace(colorString))
+            {
+                return false;
+            }
+
+            if (ColorUtility.TryParseHtmlString(colorString, out color))
+            {
+                return true;
+            }
+
+            string[] parts = colorString.Split(',');
+            if (parts.Length < 3)
+            {
+                return false;
+            }
+
+            if (float.TryParse(parts[0], out float r) &&
+                float.TryParse(parts[1], out float g) &&
+                float.TryParse(parts[2], out float b))
+            {
+                float a = 1f;
+                if (parts.Length > 3 && float.TryParse(parts[3], out float parsedAlpha))
+                {
+                    a = parsedAlpha;
+                }
+
+                color = new Color(r, g, b, a);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/ModUiRuntime.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/ModUiRuntime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4656df7610434209b884518573c4dfa3

--- a/Assets/LoopModding/Core/Scripts/ShowImageAction.cs
+++ b/Assets/LoopModding/Core/Scripts/ShowImageAction.cs
@@ -1,0 +1,73 @@
+using LoopModding.Core.Runtime;
+using SimpleJSON;
+using UnityEngine;
+
+namespace LoopModding.Core.API
+{
+    /// <summary>
+    /// Downloads an image from a remote URL and displays it on the mod UI canvas.
+    /// </summary>
+    public class ShowImageAction : ModApiAction
+    {
+        public override string ActionName => "ShowImage";
+
+        public override void Execute(JSONNode args)
+        {
+            if (args == null)
+            {
+                Debug.LogWarning("[MOD] ShowImage called without arguments.");
+                return;
+            }
+
+            string url = args.HasKey("url") ? args["url"].Value : string.Empty;
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                Debug.LogWarning("[MOD] ShowImage requires a 'url' argument.");
+                return;
+            }
+
+            string id = args.HasKey("id") ? args["id"].Value : null;
+            float x = args.HasKey("x") ? args["x"].AsFloat : 0.5f;
+            float y = args.HasKey("y") ? args["y"].AsFloat : 0.5f;
+            bool normalized = args.HasKey("normalized") && args["normalized"].AsBool;
+            float width = args.HasKey("width") ? Mathf.Max(0f, args["width"].AsFloat) : 256f;
+            float height = args.HasKey("height") ? Mathf.Max(0f, args["height"].AsFloat) : 256f;
+            float pivotX = args.HasKey("pivotX") ? Mathf.Clamp01(args["pivotX"].AsFloat) : 0.5f;
+            float pivotY = args.HasKey("pivotY") ? Mathf.Clamp01(args["pivotY"].AsFloat) : 0.5f;
+            float rotation = args.HasKey("rotation") ? args["rotation"].AsFloat : 0f;
+            float duration = args.HasKey("duration") ? Mathf.Max(0f, args["duration"].AsFloat) : 0f;
+            bool preserveAspect = args.HasKey("preserveAspect") && args["preserveAspect"].AsBool;
+
+            Color color = Color.white;
+            if (args.HasKey("color") && !ModUiRuntime.TryParseColor(args["color"].Value, out color))
+            {
+                Debug.LogWarning($"[MOD] ShowImage received an invalid color '{args["color"].Value}'. Falling back to white.");
+                color = Color.white;
+            }
+
+            if (args.HasKey("alpha"))
+            {
+                color.a = Mathf.Clamp01(args["alpha"].AsFloat);
+            }
+
+            Vector2 position = normalized ? new Vector2(Mathf.Clamp01(x), Mathf.Clamp01(y)) : new Vector2(x, y);
+            Vector2 size = new Vector2(width, height);
+            Vector2 pivot = new Vector2(pivotX, pivotY);
+
+            ModUiRuntime runtime = ModUiRuntime.EnsureInstance();
+            string elementId = runtime.ShowImage(
+                id,
+                url,
+                position,
+                normalized ? ModUiRuntime.PositionMode.Normalized : ModUiRuntime.PositionMode.Pixel,
+                size,
+                pivot,
+                rotation,
+                color,
+                preserveAspect,
+                duration);
+
+            Debug.Log($"[MOD] ShowImage displaying '{url}' with id '{elementId}'.");
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/ShowImageAction.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/ShowImageAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 080af514a8904370b419ab9169ce9d03

--- a/Assets/LoopModding/Core/Scripts/UnbindInputAction.cs
+++ b/Assets/LoopModding/Core/Scripts/UnbindInputAction.cs
@@ -1,0 +1,40 @@
+using LoopModding.Core.Runtime;
+using SimpleJSON;
+using UnityEngine;
+
+namespace LoopModding.Core.API
+{
+    /// <summary>
+    /// Removes a previously registered input binding.
+    /// </summary>
+    public class UnbindInputAction : ModApiAction
+    {
+        public override string ActionName => "UnbindInput";
+
+        public override void Execute(JSONNode args)
+        {
+            if (args == null)
+            {
+                Debug.LogWarning("[MOD] UnbindInput called without arguments.");
+                return;
+            }
+
+            string id = args.HasKey("id") ? args["id"].Value : string.Empty;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                Debug.LogWarning("[MOD] UnbindInput requires an 'id' to remove.");
+                return;
+            }
+
+            ModInputRuntime runtime = ModInputRuntime.EnsureInstance();
+            if (runtime.UnregisterBinding(id))
+            {
+                Debug.Log($"[MOD] UnbindInput removed binding '{id}'.");
+            }
+            else
+            {
+                Debug.LogWarning($"[MOD] UnbindInput could not find binding '{id}'.");
+            }
+        }
+    }
+}

--- a/Assets/LoopModding/Core/Scripts/UnbindInputAction.cs.meta
+++ b/Assets/LoopModding/Core/Scripts/UnbindInputAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4260b1bed9f044b09bccfcb2d5c83126

--- a/Mods/Addons/BindReloadInput.json
+++ b/Mods/Addons/BindReloadInput.json
@@ -1,0 +1,19 @@
+{
+  "modName": "BindReloadKey",
+  "eventName": "OnNewPlayer",
+  "action": "BindInput",
+  "args": {
+    "id": "reloadModsBinding",
+    "eventName": "ReloadFolders",
+    "key": "F5",
+    "trigger": "Down",
+    "buttonLabel": "Reload Mods (F5)",
+    "buttonNormalized": true,
+    "buttonX": 0.5,
+    "buttonY": 0.1,
+    "buttonWidth": 320,
+    "buttonHeight": 80,
+    "buttonPivotX": 0.5,
+    "buttonPivotY": 0.5
+  }
+}

--- a/Mods/Addons/DrawTextDemo.json
+++ b/Mods/Addons/DrawTextDemo.json
@@ -1,0 +1,19 @@
+{
+  "modName": "WelcomeBanner",
+  "eventName": "OnNewPlayer",
+  "action": "DrawText",
+  "args": {
+    "id": "welcomeBanner",
+    "text": "Welcome to @serverName!",
+    "x": 0.5,
+    "y": 0.85,
+    "normalized": true,
+    "fontSize": 42,
+    "color": "#FFD700",
+    "fontStyle": "Bold",
+    "alignment": "Center",
+    "duration": 6,
+    "width": 640,
+    "height": 80
+  }
+}

--- a/Mods/Addons/ShowImageDemo.json
+++ b/Mods/Addons/ShowImageDemo.json
@@ -1,0 +1,18 @@
+{
+  "modName": "ShowWelcomeBadge",
+  "eventName": "OnNewPlayer",
+  "action": "ShowImage",
+  "args": {
+    "id": "welcomeBadge",
+    "url": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Unity_2015.png",
+    "x": 0.9,
+    "y": 0.9,
+    "normalized": true,
+    "width": 256,
+    "height": 256,
+    "rotation": 0,
+    "duration": 8,
+    "preserveAspect": true,
+    "alpha": 0.95
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ It allows you to trigger actions through mod files and centralize game logic thr
 - 🧠 Parametric logic with support for `@parameters`
 - ⚡ Hot-reload support (manually via Reload button)  
 - 🛠️ Simple JSON mod files in `Mods/Addons`  
-- 💬 Chat/message injection, teleportation, etc.  
+- 💬 Chat/message injection, teleportation, etc.
 - 📁 Global `parameters.json` support via `@` placeholders
+- 🖼️ UI helpers to render remote images and rich text overlays
+- 🎮 Runtime key/UI bindings that trigger mod events
 
 🧩 Mod Structure
 ----------------
@@ -101,6 +103,72 @@ These are handled automatically after the main action is executed.
 | PrintMessage      | Logs a message (use chatMessage too)                    |
 | OnPlayerArrested  | Teleports the player or prints a message for that event |
 | TeleportPlayer    | Teleports the player to x/y/z                           |
+| DrawText          | Renders stylable text overlays on the shared mod canvas |
+| ShowImage         | Downloads a remote image and displays it on the canvas  |
+| BindInput         | Maps a key or UI button to trigger a named mod event    |
+| UnbindInput       | Removes a previously registered input binding           |
+
+📺 UI Helpers & Input Bindings
+------------------------------
+The runtime automatically spawns a lightweight UI canvas (`ModUiRuntime`) the first time you use the new UI related actions.
+All coordinates support **pixel** or **normalized (0..1)** positioning via the `normalized` / `buttonNormalized` booleans.
+
+### DrawText
+```json
+{
+  "action": "DrawText",
+  "args": {
+    "text": "Welcome to @serverName!",
+    "x": 0.5,
+    "y": 0.85,
+    "normalized": true,
+    "fontSize": 42,
+    "color": "#FFD700",
+    "fontStyle": "Bold|Italic",
+    "duration": 6
+  }
+}
+```
+- Optional args: `id`, `width`, `height`, `pivotX/Y`, `alignment`, `raycastTarget`.
+
+### ShowImage
+```json
+{
+  "action": "ShowImage",
+  "args": {
+    "url": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Unity_2015.png",
+    "id": "welcomeBadge",
+    "x": 0.9,
+    "y": 0.9,
+    "normalized": true,
+    "width": 256,
+    "height": 256,
+    "duration": 8,
+    "preserveAspect": true
+  }
+}
+```
+- Optional args: `rotation`, `color`, `alpha`, `pivotX/Y`.
+
+### BindInput / UnbindInput
+```json
+{
+  "action": "BindInput",
+  "args": {
+    "id": "reloadModsBinding",
+    "eventName": "ReloadFolders",
+    "key": "F5",
+    "buttonLabel": "Reload Mods (F5)",
+    "buttonNormalized": true,
+    "buttonX": 0.5,
+    "buttonY": 0.1
+  }
+}
+```
+- Optional key args: `trigger` (`Down`, `Up`, `Held`), `holdDelay`, `repeatInterval`.
+- Optional button args: `buttonWidth`, `buttonHeight`, `buttonPivotX/Y`, `buttonDuration`, `buttonInteractable`.
+
+Use `UnbindInput` with an `id` to remove either key or button at runtime.
 
 All built-in actions are automatically discovered at startup. To add your own, create a new C# script that inherits from `ModApiAction` and override `ActionName` + `Execute`:
 


### PR DESCRIPTION
## Summary
- add a ModUiRuntime utility to host dynamic text, image, and button content for mods
- expose DrawText, ShowImage, BindInput, and UnbindInput actions backed by the new runtime helpers
- document the UI/input workflow and provide example mods for drawing text, showing images, and binding reload controls

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c973d25820832abee1195cddc280a7